### PR TITLE
Fix for map closing bug

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -180,7 +180,7 @@ impl Game {
         }
 
         // reduce map size if needed
-        if self.shrink_at_turn < self.turn {
+        if self.shrink_at_turn <= self.turn {
             if let Some(shrink_location) =
                 calculate_shrink_location(self.turn - self.shrink_at_turn, self.width, self.height)
             {


### PR DESCRIPTION
Bomb radius = 2
Explosion = 💣
Walls = 🟥
Destroyable = 🟫
Empty = ⬜
Player = 👤

Map With Bomb
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥👤⬜🟫⬜⬜⬜⬜🟥
🟥🟫🟥🟫⬜🟫🟥🟫🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥👤⬜🟫⬜⬜⬜⬜🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

First shrink before
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥👤🟥🟫⬜⬜⬜⬜🟥
🟥🟫🟥🟫⬜🟫🟥🟫🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥👤⬜🟫⬜⬜⬜⬜🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

first shrink after
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥👤🟫⬜⬜⬜⬜🟥
🟥🟫🟥🟫⬜🟫🟥🟫🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥⬜⬜🟫⬜⬜⬜⬜🟥
🟥👤⬜🟫⬜⬜⬜⬜🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

Before after the map would complete close (top left will never be filled player can get stuck there when the second layer closes)
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥👤🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

Now after the map would complete close
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

This was a problem because after some time you get this situation (now not possible anymore)
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥👤🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥⬜🟫🟥🟥🟥
🟥🟥⬜🟫⬜⬜⬜🟥🟥
🟥🟥⬜🟫⬜👤⬜🟥🟥
🟥🟥⬜🟫⬜⬜⬜🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥
🟥🟥🟥🟥🟥🟥🟥🟥🟥

After this update my bot became extremely bad ):